### PR TITLE
Upgrade to `mautic/api-library v4.0.0-beta` to fix incompatibility with `psr/log` v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
         "illuminate/contracts": "^10.0|^11.0",
         "illuminate/notifications": "^10.0|^11.0",
         "league/oauth2-client": "^2.6",
-        "mautic/api-library": "^3.1",
-        "psr/log": "^2",
+        "mautic/api-library": "^4.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
@@ -75,6 +74,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
+            "php-http/discovery": true,
             "phpstan/extension-installer": true
         }
     },

--- a/src/Auth/Authenticator/AbstractAuthenticator.php
+++ b/src/Auth/Authenticator/AbstractAuthenticator.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Str;
 use Mautic\Response;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 abstract class AbstractAuthenticator implements AuthenticatorInterface
 {
@@ -68,11 +67,7 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
         $httpResponse = $this->client->sendRequest($request);
 
         // Parse response
-        $response = new Response((string) $httpResponse->getBody(), $this->getCurlInfo($httpResponse));
-
-        // TODO: Implement this
-        // $this->_httpResponseHeaders = $response->getHeaders();
-        // $this->_httpResponseInfo    = $response->getInfo();
+        $response = new Response($httpResponse);
 
         // Handle zip file response
         if ($response->isZip()) {
@@ -101,16 +96,5 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
         }
 
         return [$url, $params];
-    }
-
-    /**
-     * @see \curl_getinfo()
-     */
-    private function getCurlInfo(ResponseInterface $httpResponse): array
-    {
-        return [
-            'content_type' => $httpResponse->hasHeader('content-type') ? $httpResponse->getHeader('content-type')[0] : '',
-            'http_code' => $httpResponse->getStatusCode(),
-        ];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR upgrades `mautic/api-library` from `v3.1.0` to `v4.0.0-beta` and removes the explicit constraint of `psr/log` v2, so the v3 can be used. 

This allows users who cannot downgrade to `psr/log` v2 to still be able to use this library.

> [!IMPORTANT]
> This PR is intended to be merged and released under a `beta` pre-release tag. E.g: `1.0.0-beta` or `0.4.0-beta`. DO NOT release this under a stable version, otherwise it could affect existing consumers of the package. 

## Motivation and context

Fixes #38. The solution is also discused in #39.

The problem is the following:
- `mautic/api-library` hasn't released a new stable version since 2022.
- The current stable version of `mautic/api-library` v3.1.0 released on 2022 is incompatible with `psr/log` v3.
- The pre-release version of `mautic/api-library` v4.0.0-beta released on Sep 3, 2024 addresses this issue and makes the library compatible with `psr/log` v3. However, it's been 4 months since that beta version and it is unknown if a new stable version will be released soon.

The proposed solution is the following:
- Bump `mautic/api-library` from `v3.1.0` to `v4.0.0-beta` so we can benefit from the new features and bug fixes of the new release.
- Publish `swisnl/laravel-mautic` as `v1.0.0-beta` or `v0.4.0-beta` so it can be used in the meantime until `mautic/api-library` publishes a new stable version. It must be published with a `beta` pre-release version so composer doesn't use that version by default. 

## How has this been tested?

To be frank, I haven't tested it in depth because I don't have the tools to do so. I [forked the repo](https://github.com/jhm-ciberman/laravel-mautic/tree/mautic-api-library-v4), installed the dependencies, made the changes and run the tests.

After that I pushed to my fork and tested in my own private company project that the package installs correctly against my own branch:

```json
{
    "require": {
        "mautic/api-library": "4.0.0-beta@beta",
        "swisnl/laravel-mautic": "dev-mautic-api-library-v4@dev",
    },
    "repositories": {
        "laravel-mautic": {
            "type": "vcs",
            "url": "https://github.com/jhm-ciberman/laravel-mautic.git"
        }
    }
}
```

I haven't manually tested the integration of mautic because I don't have any mautic integration code to test in the first place. But I think that is out of scope of this package and it's responsibility of the `mautic/api-library` package. 

You can help me by skimming the [diff between v3.1.0 and v4.0.0-beta](https://github.com/mautic/api-library/compare/3.1.0...4.0.0-beta) and [v4.0.0-beta changelog](https://github.com/mautic/api-library/releases/tag/4.0.0-beta) to check if you can identify any breaking change there in any method that this package uses.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
